### PR TITLE
Add support for pipenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ word_vectors/
 see_json.json
 *.pem 
 commands.txt
+Pipfile*


### PR DESCRIPTION
Pipenv installs packages with the `requirement.txt` but it generates
a few extra `Pipfiles`, so ignoring these files helps `pipenv` users.

Fixes issue #15 